### PR TITLE
Fix sidekiq_threshold ignored on first failure

### DIFF
--- a/spec/rollbar/plugins/sidekiq_spec.rb
+++ b/spec/rollbar/plugins/sidekiq_spec.rb
@@ -107,7 +107,7 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
 
     context 'with a sidekiq_threshold set' do
       before do
-        Rollbar.configuration.sidekiq_threshold = 2
+        Rollbar.configuration.sidekiq_threshold = 3
       end
 
       it 'does not send error to rollbar under the threshold' do
@@ -140,16 +140,14 @@ describe Rollbar::Sidekiq, :reconfigure_notifier => false do
         )
       end
 
-      it 'does not blow up and sends the error to rollbar if retry is true but there is no retry count' do
+      it "does not blow up and doesn't send the error to rollbar if retry is true but there is no retry count" do
         allow(Rollbar).to receive(:scope).and_return(rollbar)
-        expect(rollbar).to receive(:error)
+        expect(rollbar).to receive(:error).never
 
-        expect do
-          described_class.handle_exception(
-            { :job => { 'retry' => true } },
-            exception
-          )
-        end.to_not raise_error
+        described_class.handle_exception(
+          { :job => { 'retry' => true } },
+          exception
+        )
       end
     end
   end


### PR DESCRIPTION
DO NOT MERGE: This is just a placeholder PR to explain what's happening here.

We're using this branch in our Gemfile while rollbar/rollbar-gem#761 makes its way to master. I originally created the PR with a fork on my own Github account (ejoubaud/), so I'm pushing it here too (envato/ fork) so we can have a dependency on an envato repo.

As soon as rollbar/rollbar-gem#761 gets merged (or rejected), we can just delete this fork and unpin the gem.